### PR TITLE
Include the env in the s3 path

### DIFF
--- a/helpers/screenshots.js
+++ b/helpers/screenshots.js
@@ -16,11 +16,15 @@ module.exports = settings => {
     const file = url === '/' ? 'index' : url.replace('/', '');
     const filename = `${file}.png`;
     const binary = Buffer.from(data, 'base64');
+
+    // if running locally then save locally
     if (settings.env === 'local' && settings.screenshots.path) {
       const dir = path.resolve(process.cwd(), settings.screenshots.path);
       mkdir.sync(dir);
       fs.writeFileSync(path.resolve(dir, filename), binary, 'binary');
     }
+
+    // if s3 is configured then save to there
     if (settings.screenshots.s3 && settings.screenshots.s3.accessKey) {
       assert(settings.screenshots.s3.bucket, 'Bucket name is required');
       assert(settings.screenshots.s3.prefix, 'S3 prefix path is required');
@@ -34,7 +38,7 @@ module.exports = settings => {
       var params = {
         Body: binary,
         Bucket: settings.screenshots.s3.bucket,
-        Key: path.join(settings.screenshots.s3.prefix, now, filename)
+        Key: path.join(settings.screenshots.s3.prefix, settings.env, now, filename)
       };
       return new Promise((resolve, reject) => {
         s3.putObject(params, err => err ? reject(err) : resolve());


### PR DESCRIPTION
This allows us to differentiate later between screenshots from local, dev, preprod, prod etc

Also add some comments/whitespace to break up the wall of code a bit.