### PR TITLE
Add fallback option for a default user for a test suite

### DIFF
--- a/helpers/with-user.js
+++ b/helpers/with-user.js
@@ -1,4 +1,5 @@
 module.exports = settings => browser => username => {
+  username = username || settings.defaultUser;
   browser.url('/logout');
   try {
     browser.waitForVisible('[name=username]', 10000);


### PR DESCRIPTION
Allows specs to leave the user undefined and be shared across internal and external test suites.