### PR TITLE
Wait for dashboard to load before proceeding

### DIFF
--- a/helpers/with-user.js
+++ b/helpers/with-user.js
@@ -13,4 +13,5 @@ module.exports = settings => browser => username => {
   }
   browser.setValue('[name=password]', settings.users[username]);
   browser.click('[name=login]');
+  browser.waitForVisible('h1*=Hello', 20000);
 };


### PR DESCRIPTION
Sometime keycloak takes an age to redirect, and we get occasional failures due to the dashboard not loading.

Give it a while, and be sure we're on the dashboard before continuing.