### PR TITLE
Support setting Chrome flags per invocation

### DIFF
--- a/helpers/config/defaults.js
+++ b/helpers/config/defaults.js
@@ -8,7 +8,10 @@ module.exports = {
   exclude: [],
   maxInstances: 2,
   capabilities: [{
-    browserName: 'chrome'
+    browserName: 'chrome',
+    'goog:chromeOptions': {
+      args: []
+    }
   }],
   headless: true,
   logLevel: 'silent',

--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -34,8 +34,11 @@ module.exports = settings => {
     baseUrl: settings.urls[env],
     ...settings
   };
+  if (config.flags) {
+    config.capabilities[0]['goog:chromeOptions'].args.push(...config.flags);
+  }
   if (config.headless) {
-    config.capabilities[0]['goog:chromeOptions'] = { args: ['--headless', '--disable-gpu'] };
+    config.capabilities[0]['goog:chromeOptions'].args.push('--headless', '--disable-gpu');
   }
   if (config.sample !== false) {
     config.mochaOpts.require = require.resolve('./sample');


### PR DESCRIPTION
The specific use case for this right now is to allow setting `--force-device-scale-factor=1` in visual regression tests for consistency across devices.