### PR TITLE
Delete cookies before logging out

### DIFF
--- a/helpers/with-user.js
+++ b/helpers/with-user.js
@@ -4,6 +4,7 @@ module.exports = settings => function (username) {
   username = username || settings.defaultUser;
 
   const doLogin = () => {
+    this.deleteCookies();
     this.url('/logout');
     this.$('[name=username]').waitForDisplayed({ timeout: 10000 });
     this.$('[name=username]').setValue(username);


### PR DESCRIPTION
In the mixed user tests the `baseUrl` is set to the external facing service, so `browser.url('/logout')` will always hit the external facing logout page, which doesn't log an internal user out. This results in sessions not being terminated correctly when using multiple internal users.

Add a `deleteCookies` call, which is independent of the `baseUrl` and always acts on the current page to ensure that users are always completely signed out, irrespective of what service is active at the time.