### PR TITLE
Make login selector configurable

### DIFF
--- a/helpers/with-user.js
+++ b/helpers/with-user.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-module.exports = settings => function (username) {
+module.exports = settings => function (username, selector = 'h1*=Hello') {
   username = username || settings.defaultUser;
 
   const doLogin = () => {
@@ -18,7 +18,7 @@ module.exports = settings => function (username) {
       const errorText = errorMessage[0].getText();
       assert.fail(`Login error found: ${errorText}`);
     }
-    this.$('h1*=Hello').waitForDisplayed({ timeout: 10000 });
+    this.$(selector).waitForDisplayed({ timeout: 10000 });
   };
 
   const tryLogin = (count = 0) => {


### PR DESCRIPTION
Tests for email verfication can't log in because they don't display `Hello ...` on the homepage. Make the selector configurable so that tests that don't log in to the homepage can still pass.