### PR TITLE
Scroll to top before interacting with download header

### DIFF
--- a/helpers/download-file.js
+++ b/helpers/download-file.js
@@ -5,6 +5,10 @@ const pdf = require('pdf-parse');
 const parsePDF = data => pdf(Buffer.from(data, 'binary'));
 
 const downloadFile = settings => function(fileType) {
+
+  // scroll window to top before trying to interact with download header
+  this.$('header[role="banner"]').scrollIntoView();
+
   const toggleLink = this.$('.document-header a.toggle-details');
 
   if (toggleLink.isDisplayed() && toggleLink.getText().includes('View')) {


### PR DESCRIPTION
Content changes as the user scroll on the page, so the downloads link is not visible most of the time.

Scroll to the top of the page before trying to download files to ensure that the displayed content is reliable.