### PR TITLE
Use default password if user is not defined

### DIFF
--- a/helpers/config/index.js
+++ b/helpers/config/index.js
@@ -10,6 +10,7 @@ module.exports = settings => {
   const config = {
     ...defaults,
     defaultUser: 'holc',
+    defaultPassword: process.env.KEYCLOAK_PASSWORD,
     users: {
       'unverified': process.env.KEYCLOAK_PASSWORD,
       'newuser': process.env.KEYCLOAK_PASSWORD,

--- a/helpers/with-user.js
+++ b/helpers/with-user.js
@@ -9,9 +9,9 @@ module.exports = settings => function (username, selector = 'h1*=Hello') {
     this.$('[name=username]').waitForDisplayed({ timeout: 10000 });
     this.$('[name=username]').setValue(username);
     if (!settings.users[username]) {
-      throw new Error(`Could not find user: ${username}`);
+      console.error(`Could not find user: ${username}`);
     }
-    this.$('[name=password]').setValue(settings.users[username]);
+    this.$('[name=password]').setValue(settings.users[username] || settings.defaultPassword);
     this.$('[name=login]').click();
     const errorMessage = this.$$('.alert-error');
     if (errorMessage.length) {


### PR DESCRIPTION
Rather than having to change this config every time we create a new test user, when they all use the same password anyway.