### PR TITLE
Improve download file helpers

### DIFF
--- a/helpers/install.js
+++ b/helpers/install.js
@@ -1,6 +1,6 @@
 /*global browser*/
 const withUser = require('./with-user');
-const downloadFile = require('./download-file');
+const { download, downloadFile } = require('./download-file');
 const waitForSync = require('./wait-for-sync');
 const waitForSuccess = require('./wait-for-success');
 const selectMany = require('./select-many');
@@ -19,6 +19,7 @@ module.exports = (config) => {
 
   // true as third argument extends element - i.e. `browser.$(selector).completeRichText('words')`
   browser.addCommand('completeRichText', completeRichText(config), true);
+  browser.addCommand('download', download(config), true);
   browser.addCommand('closest', closest(config), true);
 
   // add elaborate implementation of `.click()` to deal with floating elements that might block the click

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,6 +507,11 @@
         "which": "^1.2.9"
       }
     },
+    "csv-parse": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.1.tgz",
+      "integrity": "sha512-TXIvRtNp0fqMJbk3yPR35bQIDzMH4khDwduElzE7Fl1wgnl25mnWYLSLqd/wS5GsDoX1rWtysivEYMNsz5jKwQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@wdio/reporter": "^6.1.14",
     "chalk": "^4.0.0",
+    "csv-parse": "^4.15.1",
     "dotenv": "^8.2.0",
     "mocha": "^7.2.0",
     "pdf-parse": "^1.1.1",


### PR DESCRIPTION
Allow any download link to be used without it needing to be part of a download header or page. Attaches a download method onto an element so you can download the target of any download link:

```js
const content = browser.$('a=Download').download('pdf');
```

Also parses csv data into structured objects:

```js
const csv = browser.$('a=Download active licence list').download('csv');
assert.ok(csv.every(row => row.status === 'active'));
```