### PR TITLE
parse BOM correctly in CSVs

### DIFF
--- a/helpers/download-file.js
+++ b/helpers/download-file.js
@@ -45,7 +45,7 @@ const getFile = function (url, type) {
           case 'pdf':
             return parsePDF(data).then(pdf => pdf.text.replace(/\s/g, ' '));
           case 'csv':
-            return csv(data, { columns: true });
+            return csv(data, { bom: true, columns: true });
           default:
             return data.toString('utf8');
         }


### PR DESCRIPTION
We now add a BOM to CSV output to get Excel to correctly read them as UTF-8. If we don't tell the parser about it, the first column header ends up quoted when parsed after downloading e.g.

```
applicationsCsv: [
    {
      'title': 'Project with task history',
      establishment: ...
```
instead of 
```
applicationsCsv: [
    {
      title: 'Project with task history',
      establishment: ...
```
