### PR TITLE
Add method to browser for uploading images to RTEs

### DIFF
--- a/helpers/install.js
+++ b/helpers/install.js
@@ -6,6 +6,7 @@ const waitForSuccess = require('./wait-for-success');
 const selectMany = require('./select-many');
 const autocomplete = require('./autocomplete');
 const completeRichText = require('./complete-rich-text');
+const richTextImage = require('./rich-text-image');
 const closest = require('./closest');
 
 module.exports = (config) => {
@@ -19,6 +20,7 @@ module.exports = (config) => {
 
   // true as third argument extends element - i.e. `browser.$(selector).completeRichText('words')`
   browser.addCommand('completeRichText', completeRichText(config), true);
+  browser.addCommand('richTextImage', richTextImage(config), true);
   browser.addCommand('download', download(config), true);
   browser.addCommand('closest', closest(config), true);
 

--- a/helpers/rich-text-image.js
+++ b/helpers/rich-text-image.js
@@ -1,0 +1,4 @@
+module.exports = settings => function (imagePath) {
+  const file = browser.uploadFile(imagePath);
+  this.$('input[type="file"]').setValue(file);
+};


### PR DESCRIPTION
Adds a new method to the browser object for inserting images into the rich text editor.

Usage: 
```
cost path = require('path');
browser.$('#project-aim').richTextImage(path.resolve(__dirname, '../../files/add-image-to-rte.png'));
```

I was trying to think of a way we could just pass the relative file path and have the path resolution done in this function?

