### PR TITLE
Be less strict when parsing CSV strings

### DIFF
--- a/helpers/download-file.js
+++ b/helpers/download-file.js
@@ -45,7 +45,7 @@ const getFile = function (url, type) {
           case 'pdf':
             return parsePDF(data).then(pdf => pdf.text.replace(/\s/g, ' '));
           case 'csv':
-            return csv(data, { bom: true, columns: true });
+            return csv(data, { bom: true, columns: true, relax: true });
           default:
             return data.toString('utf8');
         }


### PR DESCRIPTION
The changes we made to prevent auto-conversion of strings into numbers (https://github.com/UKHomeOffice/asl-pages/pull/1295) means that we now have an `=` char before double quotes in certain cells, which `csv-parse` does not like by default.

The [relax flag](https://csv.js.org/parse/options/) tells it to ignore those chars and just convert the value.